### PR TITLE
fix calcrom.pl

### DIFF
--- a/calcrom.pl
+++ b/calcrom.pl
@@ -43,7 +43,7 @@ while (my $line = <$file>)
             }
             elsif ($dir eq 'asm')
             {
-                if (!($basename =~ /(crt0|libagbsyscall|libgcnmultiboot|m4a_1)/))
+                if (!($basename =~ /(crt0|libagbsyscall|multi_sio_asm|m4a_asm)/))
                 {
                     push @pairs, [$basename, $size];
                 }


### PR DESCRIPTION
Handwritten files should be recognized by `--verbose`. 