### PR TITLE
Match sub_08141300, dropping code_08138D64.c's hand-written bl

### DIFF
--- a/src/code_08138D64.c
+++ b/src/code_08138D64.c
@@ -4357,6 +4357,7 @@ static inline u8 GetUnk9CB(struct Unk_08138D64 *a1) {
 
 static void sub_08141300(struct Unk_08138D64 *a1) {
     u8 i;
+    u8 cursor;
     u8 r7 = a1->unk4[a1->unkA];
     u8 var = !r7 ? 3 : 4;
     struct Sprite *sprite = NULL;
@@ -4378,10 +4379,11 @@ static void sub_08141300(struct Unk_08138D64 *a1) {
             break;
         case 3:
             m4aSongNumStart(SE_MAIN_MENU_CURSOR);
-            if (!a1->unk9CA)
+            cursor = a1->unk9CA;
+            if (!cursor)
                 a1->unk9CA = var - 1;
             else
-                --a1->unk9CA;
+                a1->unk9CA = cursor - 1;
             break;
         case 4:
             m4aSongNumStart(SE_MAIN_MENU_CURSOR);
@@ -4422,12 +4424,7 @@ static void sub_08141300(struct Unk_08138D64 *a1) {
     if (!sub_08155128(GetUnk28C(a1)))
         a1->unk28C.unk1B = 0xFF;
     sub_0815604C(&a1->unkC);
-#ifdef NONMATCHING
     sub_0815604C(GetUnk28C(a1));
-#else
-    asm("ldr r0, [sp, #4]\n"
-        "bl sub_0815604C\n"); // does not work
-#endif
     for (i = 0; i < 4; ++i)
         sub_0815604C(&a1->unk2DC[i]);
     a1->unkBDC(a1);


### PR DESCRIPTION
The `asm("ldr r0, [sp, #4]\n bl sub_0815604C\n")` was not needed — the plain call already produced every instruction correctly, and the only difference was two spill slots being exchanged. Reading `a1->unk9CA` into a local in `case 3` sheds one RTL insn, which moves gcse's expression hash table from 113 to 111 buckets and renumbers the two spilled address temporaries into the slots the target uses.

Six ROMs OK. This work was AI-assisted.