### PR TITLE
update calcrom.pl

### DIFF
--- a/calcrom.pl
+++ b/calcrom.pl
@@ -38,8 +38,6 @@ my $excluded_decomp_bytes = 0;
 sub object_origin
 {
     my ($object) = @_;
-    $object =~ s{\\}{/}g;
-
     # Archive members are reported by ld as path/to/libfoo.a(member.o).
     return $1 if ($object =~ m{([^/]+\.a)\([^)]*\)\s*$});
 
@@ -74,10 +72,7 @@ while (my $line = <$file>)
 
             if ($origin eq 'asm')
             {
-                my $basename = $object;
-                $basename =~ s{\\}{/}g;
-                $basename =~ s{.*/}{};
-                $basename =~ s{\.o$}{};
+                my $basename = basename($object, ".o");
 
                 if ($decomp_excluded_asm{$basename})
                 {
@@ -127,18 +122,54 @@ my $nm_sizes_output;
     or die "ERROR: Error while getting symbol sizes: $?";
 
 my %symbol_sizes = ();
+my $total_syms = 0;
+my $undocumented = 0;
+my $previous_filtered_symbol;
+
 foreach my $line (split /\n/, $nm_sizes_output)
 {
-    if ($line =~ /^\s*[0-9a-fA-F]+\s+([0-9a-fA-F]+)\s+([Tt])\s+(\S+)\s*$/)
+    my ($size, $type, $name);
+
+    # nm -S does not print a size for every defined symbol. Accept both
+    # "address size type name" and "address type name" so that documentation
+    # counts preserve the behavior of the previous plain-nm pipeline.
+    if ($line =~ /^\s*[0-9a-fA-F]+\s+([0-9a-fA-F]+)\s+(\S)\s+(\S+)\s*$/)
     {
-        my $size = hex($1);
-        my $name = $3;
+        $size = hex($1);
+        $type = $2;
+        $name = $3;
+    }
+    elsif ($line =~ /^\s*[0-9a-fA-F]+\s+(\S)\s+(\S+)\s*$/)
+    {
+        $type = $1;
+        $name = $2;
+    }
+    else
+    {
+        next;
+    }
 
-        # nm can legitimately contain duplicate local/library symbol names.
-        # We only need sizes for asm/nonmatching functions, so ignore every
-        # other symbol rather than imposing a repository-wide uniqueness rule.
-        next unless exists $nonmatchings{$name};
+    # Preserve the previous documentation-counting semantics:
+    #   awk '{print $3}' | grep '^[^_].\{4\}' | uniq
+    # "uniq" only removes adjacent duplicates after filtering, so keep track
+    # of the previous accepted name rather than globally deduplicating symbols.
+    if ($name !~ /^_/ and length($name) >= 5)
+    {
+        if (!defined($previous_filtered_symbol) or $name ne $previous_filtered_symbol)
+        {
+            $total_syms++;
+            $undocumented++
+                if ($name =~ /(?:[Uu]nk_[0-9a-fA-F]*|sub_[0-9a-fA-F]*)/);
+            $previous_filtered_symbol = $name;
+        }
+    }
 
+    # Nonmatching function sizes need exact text-symbol matches with an
+    # available size field.
+    if (defined($size)
+        and ($type eq 'T' or $type eq 't')
+        and exists $nonmatchings{$name})
+    {
         if (exists $symbol_sizes{$name} and $symbol_sizes{$name} != $size)
         {
             die "ERROR: Nonmatching symbol '$name' has conflicting sizes in nm output.\n";
@@ -194,31 +225,9 @@ else
 $adjusted_asm_bytes == $remaining_decomp_bytes + $nonmatching_bytesum + $excluded_decomp_bytes
     or die "ERROR: adjusted asm classification is inconsistent.\n";
 
-# Note that the grep filters out all branch labels. It also requires a minimum
-# line length of 5, to filter out a ton of generated symbols (like AcCn). No
-# settings to nm seem to remove these symbols. Finally, nm prints out a separate
-# entry for whenever a name appears in a file, not just where it's defined. uniq
-# removes all the duplicate entries.
-my $base_cmd = "nm \"$elffname\" | awk '{print \$3}' | grep '^[^_].\\{4\\}' | uniq";
-# This looks for Unknown_, Unknown_, or sub_, followed by just numbers. Note that
-# it matches even if stuff precedes the unknown, like sUnknown/gUnknown.
-my $undoc_cmd = "grep '[Uu]nk_[0-9a-fA-F]*\\|sub_[0-9a-fA-F]*'";
-my $count_cmd = "wc -l";
-
-my $total_syms_as_string;
-(run (
-    command => "$base_cmd | $count_cmd",
-    buffer => \$total_syms_as_string,
-    timeout => 60
-))
-    or die "ERROR: Error while getting all symbols: $?";
-my $undocumented_as_string;
-(run (
-    command => "$base_cmd | $undoc_cmd | $count_cmd",
-    buffer => \$undocumented_as_string,
-    timeout => 60
-))
-    or die "ERROR: Error while filtering for undocumented symbols: $?";
+# Symbol documentation counts are derived from the same nm -S output above.
+# This preserves the previous filtering rules while avoiding two more nm
+# invocations and the accompanying awk/grep/uniq/wc pipelines.
 
 # Only direct references to a baserom count as remaining incbins. Generated
 # binaries and intentional binary assets may legitimately continue to use
@@ -236,7 +245,6 @@ sub parse_integer
 sub is_baserom_path
 {
     my ($path) = @_;
-    $path =~ s{\\}{/}g;
     return basename($path) =~ /^baserom(?:_[^\/]*)?\.gba$/i;
 }
 
@@ -279,16 +287,6 @@ if (-d $repo_root)
         }
     }, $repo_root);
 }
-
-# Performing addition on a string converts it to a number. Any string that fails
-# to convert to a number becomes 0. So if our converted number is 0, but our string
-# is nonzero, then the conversion was an error.
-my $undocumented = $undocumented_as_string + 0;
-(($undocumented != 0) or ($undocumented_as_string =~ /^\s*0\s*$/))
-    or die "ERROR: Cannot convert string to num: '$undocumented_as_string'";
-my $total_syms = $total_syms_as_string + 0;
-(($total_syms != 0) or ($total_syms_as_string =~ /^\s*0\s*$/))
-    or die "ERROR: Cannot convert string to num: '$total_syms_as_string'";
 
 ($total_syms != 0)
     or die "ERROR: No symbols found.";
@@ -364,8 +362,8 @@ my $documented = $total_syms - $undocumented;
 my $docPct = pct($documented, $total_syms);
 my $undocPct = pct($undocumented, $total_syms);
 print "$total_syms total symbols\n";
-print "$documented symbols documented ($docPct%)\n";
-print "$undocumented symbols undocumented ($undocPct%)\n";
+print "    $documented symbols documented ($docPct%)\n";
+print "    $undocumented symbols undocumented ($undocPct%)\n";
 print "\n";
 
 my $dataTotal = sum0 values %data_by_origin;

--- a/calcrom.pl
+++ b/calcrom.pl
@@ -1,5 +1,4 @@
 #!/usr/bin/perl
-
 # Usage:
 #   calcrom.pl <mapfile> [--verbose]
 #
@@ -9,6 +8,8 @@
 use IPC::Cmd qw[ run ];
 use Getopt::Long;
 use List::Util qw[ sum0 zip ];
+use File::Basename qw[ basename dirname ];
+use File::Find;
 
 my $verbose = "";
 
@@ -18,100 +19,192 @@ GetOptions("verbose" => \$verbose);
 open(my $file, $ARGV[0])
     or die "ERROR: could not open file '$ARGV[0]'.\n";
 
-my $src = 0;
-my $asm = 0;
-my $srcdata = 0;
-my $data = 0;
+# These are intentionally retained as assembly and therefore do not count as
+# code remaining to be decompiled. They still count toward the total number of
+# bytes of code in asm.
+my %decomp_excluded_asm = map { $_ => 1 } qw(
+    crt0
+    libagbsyscall
+    multi_sio_asm
+    m4a_asm
+);
+
+my %code_by_origin = ();
+my %data_by_origin = ();
 my @pairs = ();
+my $remaining_decomp_bytes = 0;
+my $excluded_decomp_bytes = 0;
+
+sub object_origin
+{
+    my ($object) = @_;
+    $object =~ s{\\}{/}g;
+
+    # Archive members are reported by ld as path/to/libfoo.a(member.o).
+    return $1 if ($object =~ m{([^/]+\.a)\([^)]*\)\s*$});
+
+    $object =~ s{^\./}{};
+    $object =~ s{^(?:\.\./)+}{};
+    return $1 if ($object =~ m{^([^/]+)/});
+    return "(root)";
+}
+
 while (my $line = <$file>)
 {
-    if ($line =~ /^ \.(\w+)\s+0x[0-9a-f]+\s+(0x[0-9a-f]+) (\w+)\/(.+)\.o/)
+    if ($line =~ /^ \.(\S+)\s+0x[0-9a-fA-F]+\s+(0x[0-9a-fA-F]+)\s+(.+?)\s*$/)
     {
         my $section = $1;
         my $size = hex($2);
-        my $dir = $3;
-        my $basename = $4;
+        my $object = $3;
+
+        # Zero-sized input sections contribute no ROM bytes and should not
+        # create an origin category merely because ld happened to print them.
+        next if ($size == 0);
+
+        my $origin = object_origin($object);
+
         if ($size & 3)
         {
-            $size += 4 - ($size % 3);
+            $size += 4 - ($size % 4);
         }
 
-        if ($section =~ /text/)
+        if ($section =~ /^text(?:\.|$)/)
         {
-            if ($dir eq 'src')
+            $code_by_origin{$origin} += $size;
+
+            if ($origin eq 'asm')
             {
-                $src += $size;
-            }
-            elsif ($dir eq 'asm')
-            {
-                if (!($basename =~ /(crt0|libagbsyscall|multi_sio_asm|m4a_asm)/))
+                my $basename = $object;
+                $basename =~ s{\\}{/}g;
+                $basename =~ s{.*/}{};
+                $basename =~ s{\.o$}{};
+
+                if ($decomp_excluded_asm{$basename})
+                {
+                    $excluded_decomp_bytes += $size;
+                }
+                else
                 {
                     push @pairs, [$basename, $size];
+                    $remaining_decomp_bytes += $size;
                 }
-                $asm += $size;
             }
         }
-        elsif ($section =~ /rodata/)
+        elsif ($section =~ /^(?:rodata|data)(?:\.|$)/)
         {
-            if ($dir eq 'src')
-            {
-                $srcdata += $size;
-            }
-            elsif ($dir eq 'data')
-            {
-                $data += $size;
-            }
+            # Both .rodata and initialized .data occupy bytes in the ROM
+            # image when they are linked there. Track them identically as
+            # ROM data, grouped only by their object-file origin.
+            $data_by_origin{$origin} += $size;
         }
     }
 }
+close($file);
 
 my @sorted = sort { $a->[1] <=> $b->[1] } @pairs;
+
+(my $elffname = $ARGV[0]) =~ s/\.map$/.elf/;
+my $repo_root = dirname($ARGV[0]);
+
+# Pick up nonmatching functions from asm/nonmatching filenames ending in .inc.
+# One .inc file corresponds to one fallback function in the current project
+# layout. Get all symbol sizes from nm in one invocation instead of invoking nm
+# once per nonmatching function.
+my %nonmatchings = ();
+foreach my $path (glob "$repo_root/asm/nonmatching/*.inc")
+{
+    my $name = basename($path);
+    $name =~ s/\.inc$//;
+    $nonmatchings{$name} = 0;
+}
+
+my $nm_sizes_output;
+(run (
+    command => "nm -S \"$elffname\"",
+    buffer => \$nm_sizes_output,
+    timeout => 60
+))
+    or die "ERROR: Error while getting symbol sizes: $?";
+
+my %symbol_sizes = ();
+foreach my $line (split /\n/, $nm_sizes_output)
+{
+    if ($line =~ /^\s*[0-9a-fA-F]+\s+([0-9a-fA-F]+)\s+([Tt])\s+(\S+)\s*$/)
+    {
+        my $size = hex($1);
+        my $name = $3;
+
+        # nm can legitimately contain duplicate local/library symbol names.
+        # We only need sizes for asm/nonmatching functions, so ignore every
+        # other symbol rather than imposing a repository-wide uniqueness rule.
+        next unless exists $nonmatchings{$name};
+
+        if (exists $symbol_sizes{$name} and $symbol_sizes{$name} != $size)
+        {
+            die "ERROR: Nonmatching symbol '$name' has conflicting sizes in nm output.\n";
+        }
+        $symbol_sizes{$name} = $size;
+    }
+}
+
+foreach my $name (keys %nonmatchings)
+{
+    exists $symbol_sizes{$name}
+        or die "ERROR: Could not find nonmatching symbol '$name' in '$elffname'.\n";
+    $nonmatchings{$name} = $symbol_sizes{$name};
+}
+
+my $nonmatching_count = scalar keys %nonmatchings;
+my $nonmatching_bytesum = sum0 values %nonmatchings;
+
+# The map attributes nonmatching fallback assembly to its src object. Move those
+# bytes from src to asm so that the source/assembly breakdown reflects the code
+# actually used for matching.
+my $raw_asm_bytes = $code_by_origin{'asm'} // 0;
+my $raw_src_bytes = $code_by_origin{'src'} // 0;
+$raw_asm_bytes == $remaining_decomp_bytes + $excluded_decomp_bytes
+    or die "ERROR: asm classification is inconsistent: $raw_asm_bytes total asm bytes != "
+         . "$remaining_decomp_bytes remaining + $excluded_decomp_bytes excluded.\n";
+$raw_src_bytes >= $nonmatching_bytesum
+    or die "ERROR: nonmatching code size exceeds src code size.\n";
+
+my $adjusted_src_bytes = $raw_src_bytes - $nonmatching_bytesum;
+my $adjusted_asm_bytes = $raw_asm_bytes + $nonmatching_bytesum;
+
+# Do not manufacture zero-byte origin categories during the nonmatching
+# adjustment. A category exists in the report only if it contributes bytes.
+if ($adjusted_src_bytes > 0)
+{
+    $code_by_origin{'src'} = $adjusted_src_bytes;
+}
+else
+{
+    delete $code_by_origin{'src'};
+}
+
+if ($adjusted_asm_bytes > 0)
+{
+    $code_by_origin{'asm'} = $adjusted_asm_bytes;
+}
+else
+{
+    delete $code_by_origin{'asm'};
+}
+
+$adjusted_asm_bytes == $remaining_decomp_bytes + $nonmatching_bytesum + $excluded_decomp_bytes
+    or die "ERROR: adjusted asm classification is inconsistent.\n";
 
 # Note that the grep filters out all branch labels. It also requires a minimum
 # line length of 5, to filter out a ton of generated symbols (like AcCn). No
 # settings to nm seem to remove these symbols. Finally, nm prints out a separate
 # entry for whenever a name appears in a file, not just where it's defined. uniq
 # removes all the duplicate entries.
-#
-#
-
-(my $elffname = $ARGV[0]) =~ s/\.map/.elf/;
-
-
-# Pick up non matching functions from asm/nonmatching filenames ending in .inc
-my %nonmatchings = map { ($_ =~ /^(\w+\/)+(\w+)\.inc/ ? $2 : ()) => "" } <asm/nonmatching/*>;
-foreach(keys %nonmatchings)
-{
-    (run (
-        command => "nm -S $elffname | grep $_ | awk '{print \$2}'",
-        buffer => \$nonmatchings{$_},
-        timeout => 60
-    ))
-        or die "ERROR: Error while calculating nonmatchings' size: $?";
-}
-$_ = hex($_) for values %nonmatchings;
-
-# Rectify byte counts for src and asm, as nonmatchings are wrongly reported to be in src
-my $nonmatching_bytesum = sum0 values %nonmatchings;
-$src -= $nonmatching_bytesum;
-$asm += $nonmatching_bytesum;
-
-
-# You'd expect this to take a while, because of uniq. It runs in under a second,
-# though. Uniq is pretty fast!
-my $base_cmd = "nm $elffname | awk '{print \$3}' | grep '^[^_].\\{4\\}' | uniq";
-
+my $base_cmd = "nm \"$elffname\" | awk '{print \$3}' | grep '^[^_].\\{4\\}' | uniq";
 # This looks for Unknown_, Unknown_, or sub_, followed by just numbers. Note that
 # it matches even if stuff precedes the unknown, like sUnknown/gUnknown.
 my $undoc_cmd = "grep '[Uu]nk_[0-9a-fA-F]*\\|sub_[0-9a-fA-F]*'";
-
 my $count_cmd = "wc -l";
 
-my $incbin_cmd = "find \"\$(dirname $elffname)\" \\( -name '*.s' -o -name '*.inc' \\) -exec cat {} ';' | grep -oE '^\\s*\\.incbin\\s*\"[^\"]+\"\s*,\\s*(0x)?[0-9a-fA-F]+\\s*,\\s*(0x)?[0-9a-fA-F]+' -";
-
-# It sucks that we have to run this three times, but I can't figure out how to get
-# stdin working for subcommands in perl while still having a timeout. It's decently
-# fast anyway.
 my $total_syms_as_string;
 (run (
     command => "$base_cmd | $count_cmd",
@@ -119,7 +212,6 @@ my $total_syms_as_string;
     timeout => 60
 ))
     or die "ERROR: Error while getting all symbols: $?";
-
 my $undocumented_as_string;
 (run (
     command => "$base_cmd | $undoc_cmd | $count_cmd",
@@ -128,60 +220,127 @@ my $undocumented_as_string;
 ))
     or die "ERROR: Error while filtering for undocumented symbols: $?";
 
-my $incbin_count_as_string;
-(run (
-    command => "$incbin_cmd | $count_cmd",
-    buffer => \$incbin_count_as_string,
-    timeout => 60
-))
-    or die "ERROR: Error while counting incbins: $?";
+# Only direct references to a baserom count as remaining incbins. Generated
+# binaries and intentional binary assets may legitimately continue to use
+# .incbin and should not be treated as decompilation debt.
+my $baserom_incbin_count = 0;
+my $baserom_incbin_bytes = 0;
 
-my $incbin_bytes_as_string;
-(run (
-    command => "(echo -n 'ibase=16;' ; $incbin_cmd | sed -E 's/.*,\\s*0x([0-9a-fA-F]+)/\\1/' | tr '\\n' '+'; echo '0' ) | bc",
-    buffer => \$incbin_bytes_as_string,
-    timeout => 60
-))
-    or die "ERROR: Error while calculating incbin totals: $?";
+sub parse_integer
+{
+    my ($value) = @_;
+    return hex($value) if ($value =~ /^0x/i);
+    return int($value);
+}
+
+sub is_baserom_path
+{
+    my ($path) = @_;
+    $path =~ s{\\}{/}g;
+    return basename($path) =~ /^baserom(?:_[^\/]*)?\.gba$/i;
+}
+
+if (-d $repo_root)
+{
+    find({
+        no_chdir => 1,
+        wanted => sub {
+            if (-d $File::Find::name)
+            {
+                my $name = basename($File::Find::name);
+                if ($name eq 'build' or $name eq '.git' or $name eq 'tools')
+                {
+                    $File::Find::prune = 1;
+                }
+                return;
+            }
+
+            return unless ($File::Find::name =~ /\.(?:s|inc)$/);
+            open(my $incfile, '<', $File::Find::name)
+                or die "ERROR: could not open file '$File::Find::name'.\n";
+            while (my $line = <$incfile>)
+            {
+                next unless ($line =~ /^\s*\.incbin\s*"([^"]+)"(.*)$/);
+                my $path = $1;
+                my $args = $2;
+                next unless is_baserom_path($path);
+
+                if ($args =~ /^\s*,\s*((?:0x)?[0-9a-fA-F]+)\s*,\s*((?:0x)?[0-9a-fA-F]+)/)
+                {
+                    $baserom_incbin_count++;
+                    $baserom_incbin_bytes += parse_integer($2);
+                }
+                else
+                {
+                    die "ERROR: baserom incbin in '$File::Find::name' does not have an explicit offset and size.\n";
+                }
+            }
+            close($incfile);
+        }
+    }, $repo_root);
+}
 
 # Performing addition on a string converts it to a number. Any string that fails
 # to convert to a number becomes 0. So if our converted number is 0, but our string
 # is nonzero, then the conversion was an error.
 my $undocumented = $undocumented_as_string + 0;
-(($undocumented != 0) and ($undocumented_as_string ne "0"))
+(($undocumented != 0) or ($undocumented_as_string =~ /^\s*0\s*$/))
     or die "ERROR: Cannot convert string to num: '$undocumented_as_string'";
-
 my $total_syms = $total_syms_as_string + 0;
-(($total_syms != 0) and ($total_syms_as_string ne "0"))
+(($total_syms != 0) or ($total_syms_as_string =~ /^\s*0\s*$/))
     or die "ERROR: Cannot convert string to num: '$total_syms_as_string'";
 
 ($total_syms != 0)
     or die "ERROR: No symbols found.";
 
-my $incbin_count = $incbin_count_as_string + 0;
-(($incbin_count != 0) and ($incbin_count_as_string ne "0"))
-    or die "ERROR: Cannot convert string to num: '$incbin_count_as_string'";
+sub pct
+{
+    my ($part, $total) = @_;
+    return sprintf("%.4f", $total ? 100 * $part / $total : 0);
+}
 
-my $incbin_bytes = $incbin_bytes_as_string + 0;
-(($incbin_bytes != 0) and ($incbin_bytes_as_string ne "0"))
-    or die "ERROR: Cannot convert string to num: '$incbin_bytes_as_string'";
+sub ordered_origins
+{
+    my ($values, @preferred) = @_;
+    my %seen = ();
+    my @result = ();
+    foreach my $origin (@preferred)
+    {
+        if (exists $values->{$origin})
+        {
+            push @result, $origin;
+            $seen{$origin} = 1;
+        }
+    }
+    push @result, sort grep { !$seen{$_} } keys %$values;
+    return @result;
+}
 
-my $total = $src + $asm;
-my $srcPct = sprintf("%.4f", 100 * $src / $total);
-my $asmPct = sprintf("%.4f", 100 * $asm / $total);
-
-my $documented = $total_syms - ($undocumented);
-my $docPct = sprintf("%.4f", 100 * $documented / $total_syms);
-my $undocPct = sprintf("%.4f", 100 * $undocumented / $total_syms);
+my $total = sum0 values %code_by_origin;
+($total != 0)
+    or die "ERROR: No code found in map file.\n";
 
 print "$total total bytes of code\n";
-print "$src bytes of code in src ($srcPct%)\n";
-print "$asm bytes of code in asm ($asmPct%)\n";
+foreach my $origin (ordered_origins(\%code_by_origin, qw(src asm)))
+{
+    my $bytes = $code_by_origin{$origin};
+    my $originPct = pct($bytes, $total);
+    my $preposition = ($origin eq 'src' or $origin eq 'asm') ? 'in' : 'from';
+    print "    $bytes bytes of code $preposition $origin ($originPct%)\n";
+
+    if ($origin eq 'asm')
+    {
+        my $function_word = ($nonmatching_count == 1) ? 'function' : 'functions';
+        print "        $remaining_decomp_bytes bytes of code remaining to be decompiled\n";
+        print "        $nonmatching_bytesum bytes in $nonmatching_count $function_word in asm/nonmatching\n";
+        print "        $excluded_decomp_bytes bytes excluded from decompilation tracking\n";
+    }
+}
 print "\n";
 
 if ($verbose != 0)
 {
-    # Print out bytecount of not yet decompiled code
+    # Print out bytecount of not yet decompiled code.
     print "BREAKDOWN\n";
     foreach my $item (@sorted)
     {
@@ -189,7 +348,7 @@ if ($verbose != 0)
     }
     print "\n";
 
-    # Also print out bytecount of nonmatching code
+    # Also print out bytecount of nonmatching code.
     print "NONMATCHING\n";
     my @sorted_nonmatchings =
         sort { $a->[1] <=> $b->[1] }
@@ -198,33 +357,34 @@ if ($verbose != 0)
     {
         print "    $item->[1] bytes in asm/nonmatching/$item->[0].inc\n"
     }
-
     print "\n";
 }
 
+my $documented = $total_syms - $undocumented;
+my $docPct = pct($documented, $total_syms);
+my $undocPct = pct($undocumented, $total_syms);
 print "$total_syms total symbols\n";
 print "$documented symbols documented ($docPct%)\n";
 print "$undocumented symbols undocumented ($undocPct%)\n";
-
 print "\n";
-my $dataTotal = $srcdata + $data;
-my $srcDataPct = sprintf("%.4f", 100 * $srcdata / $dataTotal);
-my $dataPct = sprintf("%.4f", 100 * $data / $dataTotal);
-my $incPct = sprintf("%.4f", 100 * $incbin_bytes / $dataTotal);
 
-if ($data == 0)
+my $dataTotal = sum0 values %data_by_origin;
+print "$dataTotal total bytes of data\n";
+foreach my $origin (ordered_origins(\%data_by_origin, qw(src data sound)))
 {
-    print "Data porting to C is 100% complete\n"
+    my $bytes = $data_by_origin{$origin};
+    my $originPct = pct($bytes, $dataTotal);
+    my $preposition = ($origin eq 'src' or $origin eq 'data' or $origin eq 'sound') ? 'in' : 'from';
+    print "    $bytes bytes of data $preposition $origin ($originPct%)\n";
+}
+print "\n";
+
+if ($baserom_incbin_count == 0)
+{
+    print "All baserom incbins have been eliminated\n";
 }
 else
 {
-    print "$dataTotal total bytes of data\n";
-    print "$srcdata bytes of data in src ($srcDataPct%)\n";
-    print "$data bytes of data in data ($dataPct%)\n";
-}
-
-if ($incbin_count == 0) {
-    print "All incbins have been eliminated\n"
-} else {
-    print "$incbin_bytes bytes of data in $incbin_count incbins ($incPct%)\n"
+    my $baseromIncbinPct = pct($baserom_incbin_bytes, $dataTotal);
+    print "$baserom_incbin_bytes bytes of data in $baserom_incbin_count baserom incbins ($baseromIncbinPct%)\n";
 }


### PR DESCRIPTION
AI-Assisted-by: ChatGPT (GPT-5.6 Thinking)

## Summary

This updates `calcrom.pl` to make its statistics more literal and easier to interpret. The main goal is to separate **where bytes are currently linked from** from **what work still remains to be decompiled**, while keeping the existing `src`/`asm` view useful.

## Changes and rationale

### Count all mapped code by origin

`total bytes of code` now includes every non-zero `.text` input section found in the linker map, not only objects under `src/` and `asm/`. Archive members such as `libc.a` and `libgcc.a` therefore contribute to the total as well.

**Rationale:** the previous total was not actually the total amount of code in the ROM. The report now treats `bytes of code in/from ...` as a mechanical provenance breakdown, so the wording can be read literally.

Zero-sized input sections are discarded while parsing and never create an origin category.

### Split assembly provenance from decompilation progress

`bytes of code in asm` continues to include all assembly-backed code. It is then broken down into three mutually exclusive categories:

- **bytes of code remaining to be decompiled** — ordinary assembly that still needs a C decompilation;
- **bytes in `asm/nonmatching` functions** — functions that already have C implementations but still use assembly fallback because they do not match;
- **bytes excluded from decompilation tracking** — intentionally retained assembly such as runtime/handwritten assembly already excluded by the script.

The number of functions represented by `asm/nonmatching/*.inc` is also reported.

**Rationale:** being written in assembly and still needing decompilation are not the same thing. `asm/nonmatching` code has already been decompiled, while intentionally retained assembly may never be decompiled at all. Keeping these categories separate makes both the physical `asm` total and the remaining workload meaningful.

The three asm subcategories are indented beneath the asm total, while all top-level code origins are indented beneath the overall code total.

### Count ROM data mechanically by origin

Data statistics now include every non-zero `.rodata` and initialized `.data` input section linked into the ROM and group those bytes by origin. This includes sources such as `sound` and archive members in addition to `src` and `data`.

The previous `Data porting to C is 100% complete` interpretation is removed.

**Rationale:** the location of data in `src/`, `data/`, `sound/`, or an archive is an objective property of the build, but it is not a reliable measure of whether that data has been fully decompiled. In particular, data can already have had its raw incbin removed while still remaining in an assembly data file. The script now reports provenance without assigning an unsupported completion meaning to it.

The origin breakdown is indented beneath `total bytes of data` to make clear that those categories form the total.

### Restrict incbin statistics to direct baserom dependencies

The incbin scan now counts only `.incbin` directives that directly reference a `baserom*.gba` file. Generated/preprocessed directories such as `build`, `.git`, and `tools` are skipped.

The baserom-incbin line also reports its percentage of total ROM data and is kept outside the indented origin breakdown.

**Rationale:** an `.incbin` is not inherently undecompiled data. Generated binaries, multiboot payloads, graphics, audio, and other intentional binary assets may legitimately remain incbin inputs even when their source is fully reconstructed. Direct baserom incbins are the mechanically identifiable case that still depends on bytes copied from the original ROM.

This statistic is intentionally a separate dimension from the origin breakdown: baserom incbins may themselves live under `data/`, `src/`, or another origin, so the percentages are not meant to sum together.

### Parse nonmatching symbol sizes once

The script now invokes `nm -S` once and records only exact `T`/`t` symbol matches for functions represented by `asm/nonmatching/*.inc`.

**Rationale:** the previous implementation invoked `nm | grep | awk` once per function, which was slower and allowed substring matches. Limiting the lookup to the exact nonmatching function names also avoids failures caused by unrelated duplicate local/library symbols in the ELF.

### Add consistency checks

The script verifies that:

- raw asm bytes equal `remaining to be decompiled + excluded`;
- adjusted asm bytes equal `remaining to be decompiled + nonmatching + excluded`;
- nonmatching bytes do not exceed the bytes initially attributed to `src`.

**Rationale:** these categories are intended to be an exact partition. If future linker/layout changes cause the parser or classification rules to miss something, the script should fail visibly rather than print internally inconsistent progress numbers.

### Fix 4-byte size rounding

The size-alignment correction now uses `% 4` instead of `% 3`.

**Rationale:** the surrounding condition checks 4-byte alignment (`$size & 3`), so `% 3` was inconsistent and could round values to the wrong size.

## Output semantics

The resulting report now has two distinct kinds of information:

- **Code/data provenance:** where ROM bytes come from in the linked image.
- **Decompilation status:** only the explicitly identified assembly categories that represent remaining work or nonmatching C implementations.

This intentionally avoids deriving a general data-decompilation percentage from directory placement or from the presence of arbitrary `.incbin` directives.

## Testing

- `perl -c calcrom.pl`
- Synthetic map and controlled `nm` fixtures covering:
  - `src`, `asm`, excluded asm, and `asm/nonmatching`;
  - archive `.text`;
  - `.rodata` and initialized `.data`;
  - `sound` and archive data;
  - zero-sized input sections;
  - direct baserom incbins and generated-binary incbins;
  - unrelated duplicate symbols in `nm -S`.
- Verified that nonmatching bytes are not counted as code remaining to be decompiled.
- Verified that the three asm subcategories sum exactly to the reported asm total.
- Verified that zero-byte input sections never create statistical origin categories.
- Verified that baserom incbins under generated/preprocessed directories are not counted twice.
- Verified that the script rejects inconsistent classifications rather than silently reporting them.

The script should additionally be run against a normal clean project build before merge so the final output can be checked against the real `katam.map` and `katam.elf`.